### PR TITLE
Flush rewrite rules only once, group hooks and methods, fix WPCS

### DIFF
--- a/feed-template.php
+++ b/feed-template.php
@@ -32,4 +32,3 @@ $feed_json = array(
 );
 
 echo json_encode($feed_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-?>

--- a/feed-template.php
+++ b/feed-template.php
@@ -1,6 +1,4 @@
 <?php
-header('Content-Type: application/json; charset=' . get_option('blog_charset'));
-
 $feed_items = array();
 $limitCount = 0;
 while (have_posts()) : the_post();

--- a/jsonfeed-wp.php
+++ b/jsonfeed-wp.php
@@ -25,7 +25,7 @@ function setup_feed_rewrite()
 }
 
 function json_feed_content_type( $content_type, $type ) {
-	if ('json' === $type) {
+	if ( 'json' === $type ) {
 		return 'application/json';
 	}
 	return $content_type;

--- a/jsonfeed-wp.php
+++ b/jsonfeed-wp.php
@@ -14,6 +14,7 @@ License:      MIT
 // Flush the rewrite rules to enable the json feed permalink
 register_activation_hook( __FILE__, 'json_feed_setup_rewrite' );
 function json_feed_setup_rewrite() {
+	json_feed_setup_feed();
 	flush_rewrite_rules();
 }
 

--- a/jsonfeed-wp.php
+++ b/jsonfeed-wp.php
@@ -14,11 +14,6 @@ License:      MIT
 add_action('init', 'setup_feed_rewrite');
 add_filter('feed_content_type', 'json_feed_content_type', 10, 2);
 
-// I don't know if there is a cleaner way to add this. There is a hook
-// feed_links_show_posts_feed, but that only controls where the main RSS
-// feed is shown or not.
-add_action('wp_head', 'json_feed_link');
-
 function setup_feed_rewrite()
 {
     // Register our function as the feed generator for the /feed/json URL
@@ -41,9 +36,10 @@ function generateJSONFeed()
 	load_template( dirname( __FILE__ ) . '/feed-template.php' );
 }
 
-function json_feed_link()
-{
-   echo '<link rel="alternate" type="application/json" title="JSON Feed" href="' . esc_url( get_feed_link('json') ) . "\" />\n";
-
-   return false;
+add_action( 'wp_head', 'json_feed_link' );
+function json_feed_link() {
+	printf(
+		'<link rel="alternate" type="application/json" title="JSON Feed" href="%s" />',
+		esc_url( get_feed_link( 'json' ) )
+	);
 }

--- a/jsonfeed-wp.php
+++ b/jsonfeed-wp.php
@@ -14,8 +14,8 @@ License:      MIT
 add_action('init', 'setup_feed_rewrite');
 add_filter('feed_content_type', 'json_feed_content_type', 10, 2);
 
-// I don't know if there is a cleaner way to add this. There is a hook 
-// feed_links_show_posts_feed, but that only controls where the main RSS 
+// I don't know if there is a cleaner way to add this. There is a hook
+// feed_links_show_posts_feed, but that only controls where the main RSS
 // feed is shown or not.
 add_action('wp_head', 'json_feed_link');
 
@@ -47,5 +47,3 @@ function json_feed_link()
 
    return false;
 }
-
-?>

--- a/jsonfeed-wp.php
+++ b/jsonfeed-wp.php
@@ -11,16 +11,19 @@ License:      MIT
 
 **************************************************************************/
 
-add_action('init', 'setup_feed_rewrite');
+// Flush the rewrite rules to enable the json feed permalink
+register_activation_hook( __FILE__, 'json_feed_setup_rewrite' );
+function json_feed_setup_rewrite() {
+	flush_rewrite_rules();
+}
 
-function setup_feed_rewrite()
-{
-    // Register our function as the feed generator for the /feed/json URL
-    add_feed('json', 'generateJSONFeed');
-
-    // Have to do this to get the new rewrite rule into WP's DB
-    global $wp_rewrite;
-    $wp_rewrite->flush_rules();
+// Register the json feed rewrite rules
+add_action( 'init', 'json_feed_setup_feed' );
+function json_feed_setup_feed() {
+	add_feed( 'json', 'json_feed_render_feed' );
+}
+function json_feed_render_feed() {
+	load_template( dirname( __FILE__ ) . '/feed-template.php' );
 }
 
 add_filter( 'feed_content_type', 'json_feed_content_type', 10, 2 );
@@ -29,11 +32,6 @@ function json_feed_content_type( $content_type, $type ) {
 		return 'application/json';
 	}
 	return $content_type;
-}
-
-function generateJSONFeed()
-{
-	load_template( dirname( __FILE__ ) . '/feed-template.php' );
 }
 
 add_action( 'wp_head', 'json_feed_link' );

--- a/jsonfeed-wp.php
+++ b/jsonfeed-wp.php
@@ -12,7 +12,6 @@ License:      MIT
 **************************************************************************/
 
 add_action('init', 'setup_feed_rewrite');
-add_filter('feed_content_type', 'json_feed_content_type', 10, 2);
 
 function setup_feed_rewrite()
 {
@@ -24,6 +23,7 @@ function setup_feed_rewrite()
     $wp_rewrite->flush_rules();
 }
 
+add_filter( 'feed_content_type', 'json_feed_content_type', 10, 2 );
 function json_feed_content_type( $content_type, $type ) {
 	if ( 'json' === $type ) {
 		return 'application/json';


### PR DESCRIPTION
Fixes #2.

- Call `flush_rewrite_rules()` only once during plugin activation.
- Fix some of WordPress coding standard suggestions.
- Group hooks together with functions. Namespace functions by prefixing `json_feed_` to all function names.

See the changeset for additional comments.