### PR TITLE
Top level filter hook

### DIFF
--- a/feed-template.php
+++ b/feed-template.php
@@ -1,5 +1,6 @@
 <?php
 
+// set up feed items array
 $feed_items = array();
 
 while ( have_posts() ) {
@@ -20,16 +21,23 @@ while ( have_posts() ) {
 	$feed_items[] = apply_filters( 'json_feed_item', $feed_item, get_post() );
 }
 
-$feed_json = array(
+// build out top level array
+$feed_top = array(
 	'version' => 'https://jsonfeed.org/version/1',
 	'user_comment' => 'This feed allows you to read the posts from this site in any feed reader that supports the JSON Feed format. To add this feed to your reader, copy the following URL -- ' . get_feed_link( 'json' ) . ' -- and add it your reader.',
 	'home_page_url' => get_home_url(),
 	'feed_url' => get_feed_link( 'json' ),
 	'title' => get_bloginfo( 'name' ),
 	'description' => get_bloginfo( 'description' ),
-	'items' => $feed_items,
 );
 
+// provide filter hook for top level array
+$feed_json = apply_filters( 'json_feed_top', $feed_top );
+
+// add items to the JSON feed array
+$feed_json['items'] = $feed_items;
+
+// provide filter hook for the JSON whole feed
 $feed_json = apply_filters( 'json_feed_feed', $feed_json );
 
 echo wp_json_encode( $feed_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );


### PR DESCRIPTION
It'd be nice to have the ability to add additional top level items more easily. While you can use the existing `json_feed_feed` hook it requires some sophisticated array manipulation to get items into the top-level section before the `items` element. This change adds a `json_feed_top` filter hook to make adding top-level items easier.