### PR TITLE
Spec says date in RFC3339 format but nothing about GMT

### DIFF
--- a/feed-template.php
+++ b/feed-template.php
@@ -39,8 +39,8 @@ while ( have_posts() ) {
 		'url' => get_permalink(),
 		'title' => html_entity_decode(get_the_title()),
 		'content_html' => get_the_content_feed( 'json' ),
-		'date_published' => get_gmt_from_date( get_the_date( 'Y-m-d H:i:s' ), 'c' ),
-		'date_modified' => get_gmt_from_date( get_the_modified_date( 'Y-m-d H:i:s' ), 'c' ),
+		'date_published' => get_the_date( 'Y-m-d\TH:i:sP'  ),
+		'date_modified' => get_the_modified_date( 'Y-m-d\TH:i:sP' ),
 		'author' => array(
 			'name' => get_the_author(),
 		),


### PR DESCRIPTION
In fact, the example in the spec specifically shows an offset, not GMT.