### PR TITLE
fix: check if max_page is set

### DIFF
--- a/feed-json-functions.php
+++ b/feed-json-functions.php
@@ -51,7 +51,7 @@ function get_link_from_json_feed( $link ) {
 
 function get_json_feed_next_url() {
 	global $paged, $wp_query;
-	if ( ! $max_page ) {
+	if ( ! isset($max_page) || ! $max_page ) {
 		$max_page = $wp_query->max_num_pages;
 	}
 


### PR DESCRIPTION
This avoids the warning:

    PHP message: PHP Warning:  Undefined variable $max_page in

that otherwise occurs